### PR TITLE
Tkurth/pytorch1.10 patch

### DIFF
--- a/train.py
+++ b/train.py
@@ -211,7 +211,7 @@ if __name__ == '__main__':
   # set up amp
   if args.amp_mode is not None:
     params.update({"amp_mode": args.amp_mode})
-  amp_dtype = None
+  amp_dtype = torch.float32
   if params.amp_mode == "fp16":
     amp_dtype = torch.float16
   elif params.amp_mode == "bf16":

--- a/train_graph.py
+++ b/train_graph.py
@@ -258,7 +258,7 @@ if __name__ == '__main__':
   # set up amp
   if args.amp_mode is not None:
     params.update({"amp_mode": args.amp_mode})
-  amp_dtype = None
+  amp_dtype = torch.float32
   if params.amp_mode == "fp16":
     amp_dtype = torch.float16
   elif params.amp_mode == "bf16":


### PR DESCRIPTION
This PR sets the amp_dtype to torch.float32 as default because None does not work with older pytorch versions.