### PR TITLE
added nccl settings with ofi plugin for perlmutter

### DIFF
--- a/export_DDP_vars.sh
+++ b/export_DDP_vars.sh
@@ -3,3 +3,9 @@ export LOCAL_RANK=$SLURM_LOCALID
 export WORLD_SIZE=$SLURM_NTASKS
 export MASTER_PORT=29500 # default from torch launcher
 
+# Special NCCL libfabric setup on Perlmutter
+NCCL_HOME=/pscratch/sd/s/sfarrell/nccl-ofi/nccl-2.15.5-plugin-rel3/install
+export LD_LIBRARY_PATH=$NCCL_HOME/lib:$NCCL_HOME/deps/lib:$LD_LIBRARY_PATH
+export NCCL_CROSS_NIC=1
+export NCCL_SOCKET_IFNAME=hsn
+export NCCL_NET="AWS Libfabric"


### PR DESCRIPTION
I just dumped the settings into the `export_DDP_vars.sh` script.
I didn't see much value in having a separate script in this repo.
I was going to put a simple script to source in the nccl installation area but just didn't decide yet the best way to do it and figured this was maybe fine.